### PR TITLE
chore: update Go version to 1.25 across all modules

### DIFF
--- a/errhandle/testdata/go.mod
+++ b/errhandle/testdata/go.mod
@@ -1,6 +1,6 @@
 module testdata
 
-go 1.23
+go 1.25
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qor5/linter
 
-go 1.24.9
+go 1.25
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/gormlint/testdata/go.mod
+++ b/gormlint/testdata/go.mod
@@ -1,8 +1,6 @@
 module testdata
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.25
 
 require gorm.io/gorm v1.30.1
 

--- a/mustreceive/testdata/go.mod
+++ b/mustreceive/testdata/go.mod
@@ -1,8 +1,6 @@
 module testdata
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.25
 
 require github.com/theplant/appkit v0.0.0-20250317082139-cf11351af1e5
 

--- a/useany/testdata/go.mod
+++ b/useany/testdata/go.mod
@@ -1,5 +1,3 @@
 module testdata
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.25


### PR DESCRIPTION
Updated the Go version in go.mod and all testdata modules from 1.23/1.24.9 to 1.25, and removed toolchain directives where present.