### PR TITLE
chore: update Go version to 1.25.5 in Dockerfile and go.mod

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - for building custom golangci-lint
-FROM golang:1.24.9-alpine AS builder
+FROM golang:1.25.5-alpine AS builder
 
 # Install required build tools
 RUN apk add --no-cache git make curl bash
@@ -26,7 +26,7 @@ RUN echo "Building custom golangci-lint with custom plugins..." && \
     echo "Custom golangci-lint built successfully"
 
 # Runtime stage - final image with Go environment
-FROM golang:1.24.9-alpine
+FROM golang:1.25.5-alpine
 
 # Install runtime dependencies
 RUN apk add --no-cache bash sed grep git

--- a/errhandle/testdata/go.mod
+++ b/errhandle/testdata/go.mod
@@ -1,6 +1,6 @@
 module testdata
 
-go 1.25
+go 1.25.5
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qor5/linter
 
-go 1.25
+go 1.25.5
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/gormlint/testdata/go.mod
+++ b/gormlint/testdata/go.mod
@@ -1,6 +1,6 @@
 module testdata
 
-go 1.25
+go 1.25.5
 
 require gorm.io/gorm v1.30.1
 

--- a/mustreceive/testdata/go.mod
+++ b/mustreceive/testdata/go.mod
@@ -1,6 +1,6 @@
 module testdata
 
-go 1.25
+go 1.25.5
 
 require github.com/theplant/appkit v0.0.0-20250317082139-cf11351af1e5
 

--- a/useany/testdata/go.mod
+++ b/useany/testdata/go.mod
@@ -1,3 +1,3 @@
 module testdata
 
-go 1.25
+go 1.25.5


### PR DESCRIPTION
Updated the Go version from 1.25/1.24.9 to 1.25.5 in both build and runtime stages of the Dockerfile, and updated the go.mod file accordingly.